### PR TITLE
식당 상세 페이지 UI 구현 및 디자인 세부 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,5 +9,9 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+    <script
+      type="text/javascript"
+      src="https://oapi.map.naver.com/openapi/v3/maps.js?ncpClientId=%VITE_NAVER_API_CLIENT_ID%&submodules=geocoder"
+    ></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,13 +18,15 @@
         "react-router-dom": "^6.26.1",
         "tailwind-scrollbar-hide": "^1.1.7"
         "react-slick": "^0.30.2",
-        "slick-carousel": "^1.8.1"
+        "slick-carousel": "^1.8.1",
+        "tailwind-scrollbar-hide": "^1.1.7"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.4.0",
         "@commitlint/config-conventional": "^19.2.2",
         "@tanstack/eslint-plugin-query": "^5.51.15",
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
+        "@types/navermaps": "^3.7.5",
         "@types/node": "^22.4.0",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
@@ -1859,6 +1861,12 @@
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
       "dev": true
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==",
+      "dev": true
+    },
     "node_modules/@types/history": {
       "version": "4.7.11",
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
@@ -1870,6 +1878,15 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/navermaps": {
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/@types/navermaps/-/navermaps-3.7.5.tgz",
+      "integrity": "sha512-RzqYi0K5xhs45+KLkeoWjz2niDjVwKMYS1/LKns2LH9L7LEMVabdmyhP7n/6fzdJnbHc1wD1Dz+lFKOgq4yzJQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "22.4.0",

--- a/package.json
+++ b/package.json
@@ -30,13 +30,15 @@
     "react-router-dom": "^6.26.1",
     "tailwind-scrollbar-hide": "^1.1.7",
     "react-slick": "^0.30.2",
-    "slick-carousel": "^1.8.1"
+    "slick-carousel": "^1.8.1",
+    "tailwind-scrollbar-hide": "^1.1.7"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.4.0",
     "@commitlint/config-conventional": "^19.2.2",
     "@tanstack/eslint-plugin-query": "^5.51.15",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
+    "@types/navermaps": "^3.7.5",
     "@types/node": "^22.4.0",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import NotFound from '@/pages/NotFound';
 import Schedule from '@/pages/Schedule';
 import SignUp from '@/pages/SignUp';
 import Store from '@/pages/Store';
+import StoreDetail from '@/pages/StoreDetail';
 
 const queryClient = new QueryClient();
 
@@ -59,6 +60,15 @@ const router = createBrowserRouter([
       </Layout>
     ),
   },
+  {
+    path: '/stores/:storeId',
+    element: (
+      <Layout>
+        <StoreDetail />
+      </Layout>
+    ),
+  },
+
   {
     path: '/schedule',
     element: (

--- a/src/components/common/CollapsibleSideView.tsx
+++ b/src/components/common/CollapsibleSideView.tsx
@@ -13,7 +13,7 @@ export default function CollapsibleSideView({
 }: CollapsibleSideViewProps) {
   return (
     <section
-      className={`transtition-all z-10 h-full duration-200 ease-in-out ${sideViewOpen ? 'w-[27%] translate-x-0' : 'w-0 translate-x-full'} mr-5 max-w-[284px] py-11`}
+      className={`transtition-all sticky top-0 z-10 h-full duration-200 ease-in-out ${sideViewOpen ? 'w-[27%] translate-x-0' : 'w-0 translate-x-full'} mr-5 max-w-[284px] py-11`}
     >
       {sideViewOpen && (
         <header className="mb-10 mt-[50px] flex justify-between font-semibold text-gray2">

--- a/src/components/common/VerticalSlider.tsx
+++ b/src/components/common/VerticalSlider.tsx
@@ -5,11 +5,13 @@ import Slider from 'react-slick';
 
 interface VerticalSliderProps {
   sideViewOpen: boolean;
+  slidesToShow: number;
   children: React.ReactNode;
 }
 
 export default function VerticalSlider({
   sideViewOpen,
+  slidesToShow,
   children,
 }: VerticalSliderProps) {
   const sliderRef = useRef<Slider | null>(null);
@@ -18,7 +20,7 @@ export default function VerticalSlider({
     infinite: true,
     vertical: true,
     verticalSwiping: true,
-    slidesToShow: 3,
+    slidesToShow,
     slidesToScroll: 1,
     arrows: false,
   };

--- a/src/components/meal-recruit/MealRecruitSlider.tsx
+++ b/src/components/meal-recruit/MealRecruitSlider.tsx
@@ -9,7 +9,7 @@ export default function MealRecruitSlider({
   sideViewOpen,
 }: MealRecruitSliderProps) {
   return (
-    <VerticalSlider sideViewOpen={sideViewOpen}>
+    <VerticalSlider sideViewOpen={sideViewOpen} slidesToShow={3}>
       {Array.from({ length: 10 }, (_, idx) => (
         <div key={idx} className="py-2">
           <MealRecruitCard />

--- a/src/components/store/StoreCard.tsx
+++ b/src/components/store/StoreCard.tsx
@@ -1,13 +1,30 @@
-import { BsFillGeoAltFill, BsFillTelephoneFill } from 'react-icons/bs';
+import {
+  BsClockFill,
+  BsFillGeoAltFill,
+  BsFillTelephoneFill,
+} from 'react-icons/bs';
 
 import Tag from '@/components/common/Tag';
 import FavoriteButton from '@/components/common/button/FavoriteButton';
 import StoreMenuImageSlider from '@/components/store/StoreMenuImageSlider';
 
-export default function StoreCard() {
+// TODO: phoneNumber 부분은 API Response 구조 보고 빼셔도 됩니다.
+interface StoreCardProps {
+  width: string;
+  height: string;
+  phoneNumber?: string;
+  showFavoriteButton?: boolean;
+}
+
+export default function StoreCard({
+  width,
+  height,
+  phoneNumber,
+  showFavoriteButton = true,
+}: StoreCardProps) {
   return (
-    <article className="w-[300px] gap-[11px]">
-      <StoreMenuImageSlider />
+    <article className={`${width} gap-[11px]`}>
+      <StoreMenuImageSlider width={width} height={height} />
 
       <section className="mt-3 flex flex-col gap-6">
         <header className="flex items-center justify-between font-semibold">
@@ -15,7 +32,9 @@ export default function StoreCard() {
             <h2 className="text-lg">식당 이름</h2>
             <span className="text-gray2">양식</span>
           </div>
-          <FavoriteButton size={18} isFavorite={false} onClick={() => {}} />
+          {showFavoriteButton && (
+            <FavoriteButton size={18} isFavorite={false} onClick={() => {}} />
+          )}
         </header>
 
         <div className="flex flex-col gap-4">
@@ -24,11 +43,17 @@ export default function StoreCard() {
             <span className="text-gray1">서울 용산구 이촌로64길 61</span>
           </p>
           <p className="flex items-center">
-            <BsFillTelephoneFill className="mr-[10px] text-gray2" size={15} />
+            <BsClockFill className="mr-[10px] text-gray2" size={15} />
             <span className="text-gray1">영업 중</span>
             <span className="mx-1 text-gray3">|</span>
             <span className="text-gray1">15:00에 브레이크타임</span>
           </p>
+          {phoneNumber && (
+            <p className="flex items-center">
+              <BsFillTelephoneFill className="mr-[10px] text-gray2" size={15} />
+              <span className="text-gray1">{phoneNumber}</span>
+            </p>
+          )}
         </div>
 
         <footer className="flex gap-2">

--- a/src/components/store/StoreListSideView.tsx
+++ b/src/components/store/StoreListSideView.tsx
@@ -1,0 +1,25 @@
+import CollapsibleSideView from '@/components/common/CollapsibleSideView';
+import StoreListSlider from '@/components/store/StoreListSlider';
+
+interface StoreListSideViewProps {
+  sideViewOpen: boolean;
+  onClose: () => void;
+}
+
+export default function StoreListSideView({
+  sideViewOpen,
+  onClose,
+}: StoreListSideViewProps) {
+  const headerContent = <span className="text-[27px]">식당 리스트</span>;
+
+  const mainContent = <StoreListSlider sideViewOpen={sideViewOpen} />;
+
+  return (
+    <CollapsibleSideView
+      sideViewOpen={sideViewOpen}
+      onClose={onClose}
+      headerContent={headerContent}
+      mainContent={mainContent}
+    />
+  );
+}

--- a/src/components/store/StoreListSlider.tsx
+++ b/src/components/store/StoreListSlider.tsx
@@ -1,0 +1,20 @@
+import VerticalSlider from '@/components/common/VerticalSlider';
+import StoreListSliderCard from '@/components/store/StoreListSliderCard';
+
+interface StoreListSliderProps {
+  sideViewOpen: boolean;
+}
+
+export default function StoreListSlider({
+  sideViewOpen,
+}: StoreListSliderProps) {
+  return (
+    <VerticalSlider sideViewOpen={sideViewOpen} slidesToShow={4}>
+      {Array.from({ length: 10 }, (_, idx) => (
+        <div key={idx} className="py-2">
+          <StoreListSliderCard />
+        </div>
+      ))}
+    </VerticalSlider>
+  );
+}

--- a/src/components/store/StoreListSliderCard.tsx
+++ b/src/components/store/StoreListSliderCard.tsx
@@ -1,4 +1,4 @@
-import FavoriteButton from '@/components/common/FavoriteButton';
+import FavoriteButton from '@/components/common/button/FavoriteButton';
 import StoreMenuImage from '@/components/store/StoreMenuImage';
 
 export default function StoreListSliderCard() {

--- a/src/components/store/StoreListSliderCard.tsx
+++ b/src/components/store/StoreListSliderCard.tsx
@@ -1,0 +1,45 @@
+import FavoriteButton from '@/components/common/FavoriteButton';
+import StoreMenuImage from '@/components/store/StoreMenuImage';
+
+export default function StoreListSliderCard() {
+  return (
+    <article className="flex w-full gap-[11px]">
+      <StoreMenuImage
+        width="w-[147px]"
+        height="h-[147px]"
+        src="/src/assets/images/food.jpg"
+      />
+
+      <div className="flex w-full flex-col gap-4">
+        <header className="font-semibold">
+          <div className="flex w-full justify-between">
+            <h2>식당이름</h2>
+            <div className="flex items-center gap-1">
+              <FavoriteButton size={14} isFavorite={false} onClick={() => {}} />
+              <span className="text-gray2">99</span>
+            </div>
+          </div>
+          <p className="text-xs text-gray1">양식</p>
+        </header>
+
+        <div>
+          <h3 className="mb-1 text-xs font-semibold">대표 메뉴</h3>
+          <ul className="text-[11px]">
+            <li className="flex gap-2">
+              <span>음식 이름</span>
+              <span>14,000원</span>
+            </li>
+            <li className="flex gap-2">
+              <span>음식 이름</span>
+              <span>14,000원</span>
+            </li>
+            <li className="flex gap-2">
+              <span>음식 이름</span>
+              <span>14,000원</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/components/store/StoreMap.tsx
+++ b/src/components/store/StoreMap.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+
+import useStoreMap from '@/hooks/useStoreMap';
+
+import StoreModal from '@/components/store/StoreModal';
+
+export default function StoreMap() {
+  const { isModalOpen, setIsModalOpen, storeMapRef, addMarker } = useStoreMap({
+    lat: 37.5665,
+    lng: 126.978,
+    zoom: 13,
+  });
+
+  useEffect(() => {
+    addMarker(37.5665, 126.978);
+  }, [addMarker]);
+
+  return (
+    <div className="relative w-full">
+      <div ref={storeMapRef} className="h-full w-full" />
+
+      {isModalOpen && <StoreModal onClose={() => setIsModalOpen(false)} />}
+    </div>
+  );
+}

--- a/src/components/store/StoreMap.tsx
+++ b/src/components/store/StoreMap.tsx
@@ -1,6 +1,10 @@
 import { useEffect } from 'react';
 
+import { useNavigate } from 'react-router-dom';
+
 import useStoreMap from '@/hooks/useStoreMap';
+
+import { BsList } from 'react-icons/bs';
 
 import StoreModal from '@/components/store/StoreModal';
 
@@ -10,7 +14,9 @@ export default function StoreMap() {
     lng: 126.978,
     zoom: 13,
   });
+  const navigate = useNavigate();
 
+  // NOTE - 마커 클릭 시 modal 띄우는 것을 보여주기 위해 임의로 찍어놓은 마커입니다. 추후에 삭제하셔도 됩니다.
   useEffect(() => {
     addMarker(37.5665, 126.978);
   }, [addMarker]);
@@ -18,6 +24,15 @@ export default function StoreMap() {
   return (
     <div className="relative w-full">
       <div ref={storeMapRef} className="h-full w-full" />
+
+      <button
+        type="button"
+        aria-label="리스트로 돌아가기"
+        className="absolute right-3 top-0 rounded-lg bg-white p-2 text-gray2"
+        onClick={() => navigate('/stores')}
+      >
+        <BsList size={16} />
+      </button>
 
       {isModalOpen && <StoreModal onClose={() => setIsModalOpen(false)} />}
     </div>

--- a/src/components/store/StoreMenuImage.tsx
+++ b/src/components/store/StoreMenuImage.tsx
@@ -1,13 +1,15 @@
 interface FoodImageProps {
+  width: string;
+  height: string;
   src: string;
 }
 
-export default function StoreMenuImage({ src }: FoodImageProps) {
+export default function StoreMenuImage({ width, height, src }: FoodImageProps) {
   return (
     <img
       src={src}
       alt="식당 대표 메뉴 사진"
-      className="size-[300px] rounded object-cover"
+      className={`${width} ${height} rounded object-cover`}
     />
   );
 }

--- a/src/components/store/StoreMenuImageSlider.tsx
+++ b/src/components/store/StoreMenuImageSlider.tsx
@@ -3,7 +3,15 @@ import Slider from 'react-slick';
 import SliderArrow from '@/components/common/SliderArrow';
 import StoreMenuImage from '@/components/store/StoreMenuImage';
 
-export default function StoreMenuImageSlider() {
+interface StoreMenuImageSliderProps {
+  width: string;
+  height: string;
+}
+
+export default function StoreMenuImageSlider({
+  width,
+  height,
+}: StoreMenuImageSliderProps) {
   const settings = {
     dots: false,
     infinite: true,
@@ -17,8 +25,16 @@ export default function StoreMenuImageSlider() {
   return (
     <div className="slider-container">
       <Slider {...settings}>
-        <StoreMenuImage src="src/assets/images/food.jpg" />
-        <StoreMenuImage src="src/assets/images/food2.jpg" />
+        <StoreMenuImage
+          src="/src/assets/images/food.jpg"
+          width={width}
+          height={height}
+        />
+        <StoreMenuImage
+          src="/src/assets/images/food2.jpg"
+          width={width}
+          height={height}
+        />
       </Slider>
     </div>
   );

--- a/src/components/store/StoreModal.tsx
+++ b/src/components/store/StoreModal.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+
+import StoreCard from '@/components/store/StoreCard';
+import StoreModalHeader from '@/components/store/StoreModalHeader';
+import StoreModalMenuList from '@/components/store/StoreModalMenuList';
+import StoreModalTabList from '@/components/store/StoreModalTabList';
+
+interface StoreModalProps {
+  onClose: () => void;
+}
+
+export default function StoreModal({ onClose }: StoreModalProps) {
+  const [tab, setTab] = useState('menu');
+
+  return (
+    <div className="absolute top-0 m-[15px] h-[calc(100%-30px)] w-[420px] overflow-y-auto rounded bg-white px-5 pt-[15px] shadow-modal scrollbar-hide">
+      <StoreModalHeader onClose={onClose} />
+
+      <StoreCard
+        showFavoriteButton={false}
+        width="w-full"
+        height="h-[269px]"
+        phoneNumber="02-111-2222"
+      />
+
+      <StoreModalTabList tab={tab} setTab={setTab} />
+
+      {tab === 'menu' && <StoreModalMenuList />}
+    </div>
+  );
+}

--- a/src/components/store/StoreModalHeader.tsx
+++ b/src/components/store/StoreModalHeader.tsx
@@ -1,0 +1,24 @@
+import { BsChevronLeft } from 'react-icons/bs';
+
+import FavoriteButton from '@/components/common/FavoriteButton';
+
+interface StoreModalHeaderProps {
+  onClose: () => void;
+}
+
+export default function StoreModalHeader({ onClose }: StoreModalHeaderProps) {
+  return (
+    <header className="mb-[10px] flex items-center justify-between">
+      <button
+        type="button"
+        aria-label="모달 닫기"
+        onClick={onClose}
+        className="text-[#d9d9d9]"
+      >
+        <BsChevronLeft />
+      </button>
+
+      <FavoriteButton size={20} isFavorite={false} onClick={() => {}} />
+    </header>
+  );
+}

--- a/src/components/store/StoreModalHeader.tsx
+++ b/src/components/store/StoreModalHeader.tsx
@@ -1,6 +1,6 @@
 import { BsChevronLeft } from 'react-icons/bs';
 
-import FavoriteButton from '@/components/common/FavoriteButton';
+import FavoriteButton from '@/components/common/button/FavoriteButton';
 
 interface StoreModalHeaderProps {
   onClose: () => void;

--- a/src/components/store/StoreModalMenu.tsx
+++ b/src/components/store/StoreModalMenu.tsx
@@ -1,0 +1,16 @@
+import StoreMenuImage from '@/components/store/StoreMenuImage';
+
+export default function StoreModalMenu() {
+  return (
+    <div className="flex flex-col">
+      <StoreMenuImage
+        width="w-[100px]"
+        height="h-[100px]"
+        src="/src/assets/images/food.jpg"
+      />
+
+      <h3>메뉴 이름</h3>
+      <span className="font-semibold">23,000원</span>
+    </div>
+  );
+}

--- a/src/components/store/StoreModalMenuList.tsx
+++ b/src/components/store/StoreModalMenuList.tsx
@@ -1,0 +1,11 @@
+import StoreModalMenu from '@/components/store/StoreModalMenu';
+
+export default function StoreModalMenuList() {
+  return (
+    <section className="flex flex-wrap gap-9">
+      {Array.from({ length: 12 }, (_, idx) => (
+        <StoreModalMenu key={idx} />
+      ))}
+    </section>
+  );
+}

--- a/src/components/store/StoreModalTabList.tsx
+++ b/src/components/store/StoreModalTabList.tsx
@@ -1,0 +1,34 @@
+type TabType = 'menu' | 'review' | 'storyTelling';
+
+const TAB_LIST = [
+  { text: '메뉴', type: 'menu' },
+  { text: '새싹후기', type: 'review' },
+  { text: '스토리텔링', type: 'storyTelling' },
+];
+
+interface StoreModalTabListProps {
+  tab: string;
+  setTab: (tab: string) => void;
+}
+
+export default function StoreModalTabList({
+  tab,
+  setTab,
+}: StoreModalTabListProps) {
+  return (
+    <nav className="mb-8 mt-10">
+      <ul className="flex justify-between font-semibold">
+        {TAB_LIST.map(({ text, type }) => (
+          <li
+            key={type}
+            className={`box-border flex w-[70px] cursor-pointer justify-center ${tab === type && 'border-b-2 border-gray2'}`}
+          >
+            <button type="button" onClick={() => setTab(type as TabType)}>
+              {text}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/src/hooks/useCollapsibleSideView.ts
+++ b/src/hooks/useCollapsibleSideView.ts
@@ -7,9 +7,13 @@ export function useCollapsibleSideView() {
   // 이런 경우에 지도는 첫 렌더링때 불러왔던 width값과, center값 등 위치값이 달라지기 때문에,
   // resize 이벤트를 걸어주어 지도 짤림 현상과 center가 맞지 않는 현상을 방지합니다.
   useEffect(() => {
-    setTimeout(() => {
+    const resizeTimeout = setTimeout(() => {
       window.dispatchEvent(new Event('resize'));
     }, 100);
+
+    return () => {
+      clearTimeout(resizeTimeout);
+    };
   }, [sideViewOpen]);
 
   const openSideView = () => setSideViewOpen(true);

--- a/src/hooks/useCollapsibleSideView.ts
+++ b/src/hooks/useCollapsibleSideView.ts
@@ -1,7 +1,16 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export function useCollapsibleSideView() {
   const [sideViewOpen, setSideViewOpen] = useState(true);
+
+  // sideView toggle로 인해서 지도의 부모 컴포넌트의 width가 변하게 됩니다.
+  // 이런 경우에 지도는 첫 렌더링때 불러왔던 width값과, center값 등 위치값이 달라지기 때문에,
+  // resize 이벤트를 걸어주어 지도 짤림 현상과 center가 맞지 않는 현상을 방지합니다.
+  useEffect(() => {
+    setTimeout(() => {
+      window.dispatchEvent(new Event('resize'));
+    }, 100);
+  }, [sideViewOpen]);
 
   const openSideView = () => setSideViewOpen(true);
   const closeSideView = () => setSideViewOpen(false);

--- a/src/hooks/useStoreMap.ts
+++ b/src/hooks/useStoreMap.ts
@@ -65,7 +65,6 @@ const useStoreMap = (mapOption: UseStoreMapOption) => {
       map: storeMapInstanceRef.current,
     });
 
-    // NOTE - 방법 고려
     naver.maps.Event.addListener(marker, 'click', () => setIsModalOpen(true));
 
     markerListRef.current.push(marker);

--- a/src/hooks/useStoreMap.ts
+++ b/src/hooks/useStoreMap.ts
@@ -1,0 +1,85 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface UseStoreMapOption {
+  lat: number;
+  lng: number;
+  zoom: number;
+}
+
+const useStoreMap = (mapOption: UseStoreMapOption) => {
+  /**
+   * storeMapRef: 단순 DOM 요소 참조용. Map이 렌더링될 위치만 제어합니다.
+   * storeMapInstanceRef: Map에 행해지는 모든 action은 이 instance로만 제어합니다.
+   */
+  const storeMapRef = useRef(null); // Map이 렌더링될 DOM 요소를 참조합니다.
+  const storeMapInstanceRef = useRef<naver.maps.Map | null>(null); // 생성된 실제 Map 객체를 저장합니다.
+  const markerListRef = useRef<naver.maps.Marker[]>([]);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  // Map 초기화하는 hook 입니다.
+  useEffect(() => {
+    const DEFAULT_OPTIONS = {
+      center: new naver.maps.LatLng(mapOption.lat, mapOption.lng),
+      zoom: mapOption.zoom,
+      minZoom: 7,
+      zoomControl: false,
+      disableKineticPan: false,
+    };
+
+    if (!storeMapRef.current) {
+      return;
+    }
+
+    storeMapInstanceRef.current = new naver.maps.Map(
+      storeMapRef.current,
+      DEFAULT_OPTIONS,
+    );
+
+    // eslint-disable-next-line consistent-return
+    return () => {
+      if (storeMapInstanceRef.current) {
+        storeMapInstanceRef.current.destroy();
+      }
+    };
+  }, [mapOption.lat, mapOption.lng, mapOption.zoom]);
+
+  /**
+   * 지도의 중심을 설정하는 함수입니다.
+   */
+  const setCenter = useCallback((lat: number, lng: number) => {
+    if (storeMapInstanceRef.current) {
+      storeMapInstanceRef.current.setCenter(new naver.maps.LatLng(lat, lng));
+    }
+  }, []);
+
+  /**
+   * 지도에 마커를 추가하는 함수입니다.
+   */
+  const addMarker = useCallback((lat: number, lng: number) => {
+    if (!storeMapInstanceRef.current) {
+      return null;
+    }
+
+    const marker = new naver.maps.Marker({
+      position: new naver.maps.LatLng(lat, lng),
+      map: storeMapInstanceRef.current,
+    });
+
+    // NOTE - 방법 고려
+    naver.maps.Event.addListener(marker, 'click', () => setIsModalOpen(true));
+
+    markerListRef.current.push(marker);
+
+    return marker;
+  }, []);
+
+  return {
+    storeMapRef,
+    isModalOpen,
+    setIsModalOpen,
+    setCenter,
+    addMarker,
+  };
+};
+
+export default useStoreMap;

--- a/src/layouts/MainView.tsx
+++ b/src/layouts/MainView.tsx
@@ -5,5 +5,5 @@ interface Props {
 }
 
 export default function MainView({ children }: Props) {
-  return <main className="flex-1 px-9 py-11">{children}</main>;
+  return <main className="flex flex-1 flex-col px-9 py-11">{children}</main>;
 }

--- a/src/pages/Store.tsx
+++ b/src/pages/Store.tsx
@@ -34,7 +34,7 @@ export default function Store() {
           <StoreFilterForm />
 
           <div className="flex-auto">
-            <div className="flex justify-between">
+            <div className="mb-6 flex justify-between">
               <Title title="맛집 리스트" />
               <button
                 type="button"

--- a/src/pages/Store.tsx
+++ b/src/pages/Store.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from 'react-router-dom';
+
 import { useCollapsibleSideView } from '@/hooks/useCollapsibleSideView';
 
 import Header from '@/layouts/Header';
@@ -13,6 +15,7 @@ import StoreFilterForm from '@/components/store/StoreFilterForm';
 export default function Store() {
   const { sideViewOpen, openSideView, closeSideView } =
     useCollapsibleSideView();
+  const navigate = useNavigate();
 
   return (
     <>
@@ -31,16 +34,22 @@ export default function Store() {
           <StoreFilterForm />
 
           <div className="flex-auto">
-            <div className="mb-6 flex items-center justify-between">
+            <div className="flex justify-between">
               <Title title="맛집 리스트" />
-              <div className="flex size-[30px] items-center justify-center rounded-full bg-white">
+              <button
+                type="button"
+                className="flex size-[30px] items-center justify-center rounded-full bg-white"
+                aria-label="식당 상세보기로 이동"
+                // TODO: 후에 라우팅 수정
+                onClick={() => navigate('/stores/1')}
+              >
                 <BsMap className="text-gray2" />
-              </div>
+              </button>
             </div>
 
             <div className="flex flex-wrap justify-around gap-9 text-xs">
               {Array.from({ length: 12 }, (_, idx) => (
-                <StoreCard key={idx} />
+                <StoreCard key={idx} width="w-[300px]" height="h-[300px]" />
               ))}
             </div>
           </div>

--- a/src/pages/StoreDetail.tsx
+++ b/src/pages/StoreDetail.tsx
@@ -1,0 +1,50 @@
+import { useCollapsibleSideView } from '@/hooks/useCollapsibleSideView';
+
+import Header from '@/layouts/Header';
+import MainView from '@/layouts/MainView';
+import { BsChevronLeft } from 'react-icons/bs';
+
+import Input from '@/components/common/Input';
+import StoreFilterForm from '@/components/store/StoreFilterForm';
+import StoreListSideView from '@/components/store/StoreListSideView';
+import StoreMap from '@/components/store/StoreMap';
+
+export default function StoreDetail() {
+  const { sideViewOpen, openSideView, closeSideView } =
+    useCollapsibleSideView();
+
+  return (
+    <>
+      <MainView>
+        <Header title="새싹에서 맛집을 소개해드려요!" highlight="새싹">
+          <Input
+            name="search"
+            placeholder="검색어를 입력해 주세요"
+            width="w-[422px]"
+            height="h-[40px]"
+            onChange={() => {}}
+          />
+        </Header>
+
+        <section className="flex h-full w-full gap-8">
+          <StoreFilterForm />
+
+          <StoreMap />
+        </section>
+      </MainView>
+
+      <StoreListSideView sideViewOpen={sideViewOpen} onClose={closeSideView} />
+
+      {!sideViewOpen && (
+        <button
+          type="button"
+          aria-label="사이드뷰 펼치기"
+          className="mt-24 flex size-10 items-center justify-center rounded-lg bg-white text-gray2"
+          onClick={openSideView}
+        >
+          <BsChevronLeft />
+        </button>
+      )}
+    </>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -34,6 +34,7 @@ export default {
       },
       boxShadow: {
         card: '2px 4px 12px 0px rgba(0, 0, 0, 0.08)',
+        modal: '2px 2px 16px 0px rgba(0, 0, 0, 0.25)',
       },
     },
   },


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- **SideView를 스크롤을 내려도 편하게 볼 수 있도록 sticky로 수정하였습니다.**
- **식당 상세 페이지를 구현했습니다.**
  - 식당 리스트들이 보여지는 SideView를 구현하였습니다.
    - SideView에 들어가는 수직 Slide에 한 번에 보여질 슬라이드의 수를 Props로 받도록 수정하였습니다.
  - 네이버 맵 API를 연동하여 지도를 띄웠습니다.
    - 필요한 hook을 구현하였습니다.
      - 지도 init
      - map의 center 맞추기
      - marker 추가하기
      - API 연동에 필요한 환경변수는 notion > Frontend > .env 에서 확인가능합니다. local에서 돌릴 시 개인 프로젝트에 추가해주세요.
  - 마커를 클릭 시 해당 식당의 상세 정보가 뜨도록 modal을 구현하였습니다.

## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### 식당 상세 페이지 (사이드 뷰 open)
![image](https://github.com/user-attachments/assets/1ea23a8c-bf60-4d78-a19f-723b6669726b)

### 식당 상세 페이지 (사이드 뷰 close)
![image](https://github.com/user-attachments/assets/42a1c1b6-7337-4aff-9070-6b4892239218)

### 식당 상세 Modal (사이드 뷰 open)
![image](https://github.com/user-attachments/assets/e32c1440-2bb8-4e0e-907a-1ad63c926c85)

### 식당 상세 Modal (사이드 뷰 close)
![image](https://github.com/user-attachments/assets/8163b289-f8c2-4f0e-974e-5c9e9a17800b)