### PR TITLE
fix: 한끼팟 생성 필드 유효성 검사 및 약속시간 저장 값 수정

### DIFF
--- a/src/components/store/meal-recruit/MealRecruitCard.tsx
+++ b/src/components/store/meal-recruit/MealRecruitCard.tsx
@@ -1,10 +1,8 @@
 import { useCallback } from 'react';
 
-import { convertUtcToLocal } from '@/utils/convertUtcToLocal';
-
 import { useDialogContext } from '@/hooks';
 import { MealPosts } from '@/types/store/storeMealPostDto';
-import { formatDate } from '@/utils';
+import { convertUtcToLocal, formatDate } from '@/utils';
 
 import MealRecruitCardModal from '@/components/store/meal-recruit/MealRecruitCardModal';
 import UserImage from '@/components/user/UserImage';

--- a/src/components/store/meal-recruit/MealRecruitCard.tsx
+++ b/src/components/store/meal-recruit/MealRecruitCard.tsx
@@ -26,6 +26,21 @@ export default function MealRecruitCard({
 
   const isDisabled = false;
 
+  // TODO - 공통 유틸함수로 분리 (서버에서 받은 UTC 시간 문자열을 로컬 시간으로 변환하는 로직)
+  // UTC 시간 문자열
+  const utcTimeString = slideItem.appointmentTime;
+
+  // UTC 시간을 구성하는 연, 월, 일, 시, 분, 초 값을 분리
+  const [year, month, day, hour, minute, second] = utcTimeString
+    .split(/[-T:]/)
+    .map(Number);
+
+  // Date.UTC를 사용하여 UTC 시간을 밀리초(Timestamp)로 변환
+  const utcTimestamp = Date.UTC(year, month - 1, day, hour, minute, second);
+
+  // 변환된 Timestamp 값으로 Date 객체 생성 (로컬 시간으로 변환됨)
+  const localDate = new Date(utcTimestamp);
+
   return (
     <div className="h-full w-full text-start">
       <div
@@ -46,7 +61,7 @@ export default function MealRecruitCard({
             </span>
             <span className={`${isDisabled && 'text-gray1'}`}>
               {slideItem
-                ? `${formatDate(slideItem.appointmentTime, 'yyyy.MM.dd a h시')}`
+                ? `${formatDate(localDate, 'yyyy.MM.dd a h시 mm분')}`
                 : '-'}
             </span>
           </p>

--- a/src/components/store/meal-recruit/MealRecruitCard.tsx
+++ b/src/components/store/meal-recruit/MealRecruitCard.tsx
@@ -1,5 +1,7 @@
 import { useCallback } from 'react';
 
+import { convertUtcToLocal } from '@/utils/convertUtcToLocal';
+
 import { useDialogContext } from '@/hooks';
 import { MealPosts } from '@/types/store/storeMealPostDto';
 import { formatDate } from '@/utils';
@@ -26,21 +28,6 @@ export default function MealRecruitCard({
 
   const isDisabled = false;
 
-  // TODO - 공통 유틸함수로 분리 (서버에서 받은 UTC 시간 문자열을 로컬 시간으로 변환하는 로직)
-  // UTC 시간 문자열
-  const utcTimeString = slideItem.appointmentTime;
-
-  // UTC 시간을 구성하는 연, 월, 일, 시, 분, 초 값을 분리
-  const [year, month, day, hour, minute, second] = utcTimeString
-    .split(/[-T:]/)
-    .map(Number);
-
-  // Date.UTC를 사용하여 UTC 시간을 밀리초(Timestamp)로 변환
-  const utcTimestamp = Date.UTC(year, month - 1, day, hour, minute, second);
-
-  // 변환된 Timestamp 값으로 Date 객체 생성 (로컬 시간으로 변환됨)
-  const localDate = new Date(utcTimestamp);
-
   return (
     <div className="h-full w-full text-start">
       <div
@@ -61,7 +48,7 @@ export default function MealRecruitCard({
             </span>
             <span className={`${isDisabled && 'text-gray1'}`}>
               {slideItem
-                ? `${formatDate(localDate, 'yyyy.MM.dd a h시 mm분')}`
+                ? `${formatDate(convertUtcToLocal(slideItem.appointmentTime), 'yyyy.MM.dd a h시 mm분')}`
                 : '-'}
             </span>
           </p>

--- a/src/components/store/meal-recruit/MealRecruitCardModal.tsx
+++ b/src/components/store/meal-recruit/MealRecruitCardModal.tsx
@@ -5,6 +5,8 @@ import { useQueryClient } from '@tanstack/react-query';
 import { usePutMealPost } from '@/services/store/storeMutations';
 import { useGetMealPostDetail } from '@/services/store/storeQueries';
 
+import { convertUtcToLocal } from '@/utils/convertUtcToLocal';
+
 import { useDialogContext } from '@/hooks';
 import { formatDate } from '@/utils';
 import { FaCrown } from 'react-icons/fa';
@@ -59,7 +61,7 @@ export default function MealRecruitCardModal({
 
           <span className="flex flex-1 gap-1 overflow-hidden">
             {data
-              ? `${formatDate(data.appointmentTime, 'yyyy.MM.dd a h시')}`
+              ? `${formatDate(convertUtcToLocal(data.appointmentTime), 'yyyy.MM.dd a h시 mm분')}`
               : '-'}
           </span>
         </div>

--- a/src/components/store/meal-recruit/MealRecruitCardModal.tsx
+++ b/src/components/store/meal-recruit/MealRecruitCardModal.tsx
@@ -5,10 +5,8 @@ import { useQueryClient } from '@tanstack/react-query';
 import { usePutMealPost } from '@/services/store/storeMutations';
 import { useGetMealPostDetail } from '@/services/store/storeQueries';
 
-import { convertUtcToLocal } from '@/utils/convertUtcToLocal';
-
 import { useDialogContext } from '@/hooks';
-import { formatDate } from '@/utils';
+import { convertUtcToLocal, formatDate } from '@/utils';
 import { FaCrown } from 'react-icons/fa';
 
 import SquareButton from '@/components/common/button/SquareButton';

--- a/src/components/store/meal-recruit/MealRecruitModal.tsx
+++ b/src/components/store/meal-recruit/MealRecruitModal.tsx
@@ -102,7 +102,7 @@ export default function MealRecruitModal() {
 
   return (
     <Modal
-      className="p-[50px]"
+      className="w-full max-w-[716px] p-[50px]"
       onToggleClick={hideDialog}
       title={
         <>

--- a/src/components/store/meal-recruit/MealRecruitModal.tsx
+++ b/src/components/store/meal-recruit/MealRecruitModal.tsx
@@ -60,14 +60,9 @@ export default function MealRecruitModal() {
 
       date.setHours(data.hourTime, data?.minuteTime || 0, 0, 0);
 
-      const localDate = new Date(
-        date.getTime() + date.getTimezoneOffset() * 60000,
-      );
-      const formattedDate = localDate.toISOString().replace('Z', '');
-
       const params = {
         title: data.title,
-        appointmentTime: formattedDate,
+        appointmentTime: date,
         meetingPlace: data.meetingPlace,
         memberCount: data.memberCount,
         storeName: data.storeName,

--- a/src/components/store/meal-recruit/mealRecruitSchema.ts
+++ b/src/components/store/meal-recruit/mealRecruitSchema.ts
@@ -17,7 +17,7 @@ export const mealRecruitSchema = z.object({
     z.undefined().refine(() => false, '시간 단위를 선택해 주세요.'),
   ]),
   minuteTime: z.union([
-    z.number().min(1, '분단위를 선택해 주세요.'),
+    z.number().min(0, '분단위를 선택해 주세요.'),
     z
       .undefined()
       .nullable()

--- a/src/types/store/storeMealPostDto.d.ts
+++ b/src/types/store/storeMealPostDto.d.ts
@@ -42,7 +42,7 @@ export interface Members {
 
 export interface PostMeal {
   title: string;
-  appointmentTime: string;
+  appointmentTime: Date;
   meetingPlace: string;
   memberCount: number;
   storeName: string;

--- a/src/utils/convertUtcToLocal.ts
+++ b/src/utils/convertUtcToLocal.ts
@@ -1,0 +1,18 @@
+/**
+ * UTC 시간을 Local 시간으로 변환하는 함수입니다.
+ * @param  utcTimeString - UTC 시간 문자열
+ */
+export const convertUtcToLocal = (utcTimeString: string) => {
+  // UTC 시간을 구성하는 연, 월, 일, 시, 분, 초 값을 분리
+  const [year, month, day, hour, minute, second] = utcTimeString
+    .split(/[-T:]/)
+    .map(Number);
+
+  // Date.UTC를 사용하여 UTC 시간을 밀리초(Timestamp)로 변환
+  const utcTimestamp = Date.UTC(year, month - 1, day, hour, minute, second);
+
+  // 변환된 Timestamp 값으로 Date 객체 생성 (로컬 시간으로 변환됨)
+  const localDate = new Date(utcTimestamp);
+
+  return localDate;
+};

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -10,6 +10,7 @@ export const formatDate = (
     | 'HH:mm'
     | 'yyyy년 M월 d일 EEEE'
     | 'yyyy.MM.dd a h시'
+    | 'yyyy.MM.dd a h시 mm분'
     | 'yyyy-MM-dd HH:mm:ss'
     | "yyyy-MM-dd'T'HH:mm:ss" = 'yyyy.MM.dd',
 ): string => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,6 +9,7 @@ export * from '@/utils/isInThisWeek';
 export * from '@/utils/formatPhoneNumber';
 export * from '@/utils/formatDate';
 export * from '@/utils/notice';
+export * from '@/utils/convertUtcToLocal';
 
 // 캘린더 관련
 export * from '@/utils/getFullCalendarEvents';


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 한끼팟 만들기 모달에서 시간 '분'에서 '00'값 선택 시 유효성 검사 에러가 나는 부분을 해결했습니다.
- 한끼팟을 만들 때 선택한 시간과 실제로 데이터가 저장되어 보여지는 시간이 18h 차이나는 버그를 수정했습니다.
- 한끼팟 만들기 모달 유효성 검사 에러 메세지가 겹쳐 보여지는 부분을 수정했습니다. (모달 크기 피그마와 동일하게 수정)

## PR 유형
어떤 변경 사항이 있나요?
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

## 작업물 사진
### 한끼팟 만들기 모달 (유효성 검사 에러 x)
<img width="884" alt="스크린샷 2025-01-06 오후 8 18 38" src="https://github.com/user-attachments/assets/9ab6f37f-2b0c-488f-9587-7875ac765937" />

### 저장한 약속시간과 보여지는 시간 동일 
<img width="314" alt="스크린샷 2025-01-06 오후 8 19 07" src="https://github.com/user-attachments/assets/e2a11440-568f-41e4-8cb1-a22a2c99eb95" />

### 한끼팟 상세
<img width="793" alt="스크린샷 2025-01-06 오후 8 19 36" src="https://github.com/user-attachments/assets/ca850dcf-1453-4e67-9b0a-7494a54a2af4" />