### PR TITLE
feat: SSE 연결 로직 추가 및 알림 표시 추가

### DIFF
--- a/src/atoms/notificationAtom.ts
+++ b/src/atoms/notificationAtom.ts
@@ -1,3 +1,5 @@
 import { atom } from 'jotai';
 
 export const notificationOpenAtom = atom(false);
+
+export const notificationServerSentEventAtom = atom(false);

--- a/src/components/notification/NotificationSSEListener.tsx
+++ b/src/components/notification/NotificationSSEListener.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from 'react';
+
+import { notificationServerSentEventAtom } from '@/atoms/notificationAtom';
+
+import { useAtom } from 'jotai';
+
+export default function NotificationSSEListener() {
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const [, setIsNotificationServerSentEventData] = useAtom(
+    notificationServerSentEventAtom,
+  );
+
+  useEffect(() => {
+    const baseURL = import.meta.env.VITE_SERVER_API_URL;
+    const sseUrl = `${baseURL}/sse/subscribe`;
+
+    const eventSource = new EventSource(sseUrl, { withCredentials: true });
+    eventSourceRef.current = eventSource;
+
+    eventSource.onmessage = event => {
+      console.log('[SSE] 데이터 수신:', event.data);
+      if (
+        event.data.trim() !== 'data: check' &&
+        event.data.trim() !== 'data: welcome'
+      ) {
+        setIsNotificationServerSentEventData(true);
+      }
+    };
+
+    eventSource.onerror = e => {
+      console.warn('[SSE] 오류:', e);
+    };
+
+    return () => {
+      eventSource.close();
+      console.log('[SSE] 연결 종료.');
+    };
+  }, [setIsNotificationServerSentEventData]);
+
+  return null;
+}

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -8,7 +8,10 @@ import {
 } from '@/services/auth/authQueries';
 import { useGetUnReadNotificationList } from '@/services/notification/notificationQueries';
 
-import { notificationOpenAtom } from '@/atoms/notificationAtom';
+import {
+  notificationOpenAtom,
+  notificationServerSentEventAtom,
+} from '@/atoms/notificationAtom';
 
 import HeaderMenu from '@/layouts/HeaderMenu';
 import { useAtom } from 'jotai';
@@ -32,12 +35,19 @@ export default function Header({
 }: Props) {
   const { pathname } = useLocation();
   const [, setIsNotificationOpenOpen] = useAtom(notificationOpenAtom);
+  const [isNotificationServerSentEvent, setIsNotificationServerSentEventData] =
+    useAtom(notificationServerSentEventAtom);
 
   const homePathname = pathname === '/' || pathname === '/admin';
 
   const { data: { profileImageUrl } = initialUserProfile } =
     useGetUserProfile();
   const { data: notificationList } = useGetUnReadNotificationList();
+
+  const openNotificationListTab = () => {
+    setIsNotificationServerSentEventData(false);
+    setIsNotificationOpenOpen(prev => !prev);
+  };
 
   return (
     <header className="mb-10 flex items-start justify-between">
@@ -58,10 +68,11 @@ export default function Header({
         <aside className="flex items-center">
           <button
             className="relative mr-6 p-1"
-            onClick={() => setIsNotificationOpenOpen(prev => !prev)}
+            onClick={() => openNotificationListTab()}
           >
             <BsBell className="size-[26px] stroke-[0.3] font-bold text-darkGray-hover" />
-            {notificationList?.length !== 0 && (
+            {(isNotificationServerSentEvent ||
+              notificationList?.length > 0) && (
               <div className="absolute right-0 top-0.5 size-2 rounded-full border bg-red-500" />
             )}
           </button>

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -5,6 +5,7 @@ import { Outlet } from 'react-router-dom';
 import NavigationBar from '@/layouts/NavigationBar';
 
 import ScrollToTop from '@/components/common/SrollToTop';
+import NotificationSSEListener from '@/components/notification/NotificationSSEListener';
 import NotificationSideView from '@/components/notification/NotificationSideView';
 
 interface LayoutProps {
@@ -15,6 +16,7 @@ interface LayoutProps {
 export default function Layout({ children, type }: LayoutProps) {
   return (
     <div className="flex min-h-screen min-w-[1200px] bg-bg">
+      <NotificationSSEListener />
       <ScrollToTop />
       <NavigationBar type={type} />
       {children || <Outlet />}


### PR DESCRIPTION
## 개요
기존 알림 아이콘 상단 붉은색 점을 표시하는 부분에 있어 SSE 연결이 추가되었습니다.
이제, 사용자에게 알림이 발생하면 실시간으로 알림 등이 변화합니다.

추가로, SSE 데이터 입력을 받는 경우
서버에서 전송하는 데이터를 string 형태로 받고 있습니다.
차후 활용 가치가 여러가지로 있으며, **우선은 "받았다!" 라는 인식만 하고 있다 보시면 됩니다.**

1. Atom 사용 중이길래, 상태 관리 전용 Notice Atom 하나 추가해서 사용 중입니다. (notificationServerSentEventAtom)
2. MainRoute 에서 동작하는 layout 최상단에 SSE 전용 컴포넌트를 만들어 넣어두었습니다. (최초 한번만 실행되도록)
3. 현재는 로컬(HTTP)상에서 계정 두 개로 로그인하여 테스트를 진행 했습니다. (정상 동작) -> **서버 업로드 이후 정상 동작 테스트를 위해 console.log를 넣어 둔 상태입니다. (ESLint Warning 발생, 우선은 무시 해 주세요! 테스트 이후 삭제 될 예정입니다.)**

## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

!작업물 사진!
![image](https://github.com/user-attachments/assets/bfdee370-69c4-498c-8367-c5dec1aee275)
- 테스트 후에 로그인쪽 코드를 롤백한 뒤 PR 글을 발견해서... welcome 메시지와 health Check 데이터만 보이지만, 타 계정에서 로그인 후 댓글 등 알림 발생 시 위와 같은 형식으로 보입니다.  

![image](https://github.com/user-attachments/assets/f1f18f88-8ef8-4599-9264-b7ecd5779c0b)
- 테스트용 console.log