### PR TITLE
PR: 찜 목록 읽기 관련 버그픽스

### DIFF
--- a/src/components/lounge/layout/LoungeSideView.tsx
+++ b/src/components/lounge/layout/LoungeSideView.tsx
@@ -19,7 +19,7 @@ export default function LoungeSideView() {
               key={project.projectId}
               className="border-t pt-3.5 first:border-t-0"
             >
-              <Link to={`/lounge/post/${project.projectId}`}>
+              <Link to={`/lounge/post/${project.postId}`}>
                 <h2 className="line-clamp-3 text-darkGray-hover">
                   {project.title}
                 </h2>

--- a/src/pages/trainee/ScrapedPostList.tsx
+++ b/src/pages/trainee/ScrapedPostList.tsx
@@ -8,7 +8,7 @@ import MainView from '@/layouts/MainView';
 
 import ScrapedPostCard from '@/components/user/ScrapedPostCard';
 
-const filter = { page: 1, size: 3 };
+const filter = { page: 1, size: 100 };
 
 export default function ScrapedPostList() {
   const params = useParams();

--- a/src/services/admin/userToManageQueries.ts
+++ b/src/services/admin/userToManageQueries.ts
@@ -120,7 +120,15 @@ export const useGetUserScrapList = (
       `/admin/users/${userId}/scrap`,
       { params: { ...params, page: params.page - 1 } },
     );
-    return data;
+    return {
+      ...data,
+      content: data.content.map(({ postType, ptype, ...rest }) => {
+        return {
+          ...rest,
+          postType: postType === 'PROJECT' ? ptype : postType,
+        };
+      }),
+    };
   };
 
   return useQuery({


### PR DESCRIPTION
## 개요
1. 프로젝트의 "곧 마감합니다!" 게시글 클릭 시 postId가 아닌 projectId로 이동되던 버그 수정
2. 찜 목록 더보기 페이지 내 찜 글이 3개까지만 보이던 문제 수정
3. 관리자 권한 사용 다른 사용자 찜 목록 읽기 수행 시 Study가 Project로 표시되던 버그 수정


## PR 유형
어떤 변경 사항이 있나요?
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
