### PR TITLE
feat: 알림탭에서 글 이동 시 View카운트 증가 구문 추가

### DIFF
--- a/src/components/notification/CardContent.tsx
+++ b/src/components/notification/CardContent.tsx
@@ -2,6 +2,8 @@ import { MouseEvent } from 'react';
 
 import { Link } from 'react-router-dom';
 
+import { axiosInstance } from '@/services/axiosInstance';
+
 import { NOTIFICATION_ROUTE, NOTIFICATION_TYPE } from '@/constants';
 import { useNotification } from '@/hooks';
 import { Notification } from '@/types';
@@ -27,7 +29,9 @@ export default function CardContent({ notification }: CardContentProps) {
   const getNotificationUrl = (inputNotiType: number, urlId: string) => {
     const routeUrl = NOTIFICATION_ROUTE[inputNotiType];
     const urls = urlId.split(',');
+
     if (urls.length === 1) {
+      axiosInstance.post(`/posts/${urlId}/view`);
       return routeUrl?.replace('{id}', urlId);
     }
     return routeUrl?.replace('{id}', urls[0]).replace('{session}', urls[1]);


### PR DESCRIPTION
## 개요
- 알림탭에서 글 이동 버튼 클릭 시 View 카운트 증가 API를 호출함.
- await가 아니기에, API를 호출하고 성공/실패 여부를 검사하지 않음.

## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
