### PR TITLE
fix: Notification 버튼 클릭 시 View가 동작하지 않던 버그 수정

### DIFF
--- a/src/components/notification/CardContent.tsx
+++ b/src/components/notification/CardContent.tsx
@@ -2,6 +2,8 @@ import { MouseEvent } from 'react';
 
 import { Link } from 'react-router-dom';
 
+import { axiosInstance } from '@/services/axiosInstance';
+
 import { NOTIFICATION_ROUTE, NOTIFICATION_TYPE } from '@/constants';
 import { useNotification } from '@/hooks';
 import { Notification } from '@/types';
@@ -32,6 +34,18 @@ export default function CardContent({ notification }: CardContentProps) {
       return routeUrl?.replace('{id}', urlId);
     }
     return routeUrl?.replace('{id}', urls[0]).replace('{session}', urls[1]);
+  };
+
+  const handleLinkClick = async () => {
+    const urls = url.split(',');
+
+    if (urls.length === 1) {
+      try {
+        await axiosInstance.post(`/posts/${url}/view`);
+      } catch (error) {
+        console.error('Post view 요청 실패:', error);
+      }
+    }
   };
 
   return (
@@ -66,6 +80,7 @@ export default function CardContent({ notification }: CardContentProps) {
       {buttonText && (
         <Link
           to={getNotificationUrl(notiType, url)}
+          onClick={handleLinkClick}
           className="ml-auto mt-[20px] flex items-center rounded-lg bg-mainGray-active px-[10px] py-2 text-[15px] text-white"
         >
           {buttonText}


### PR DESCRIPTION
## 개요
**알림 탭 내 카드에서 버튼 클릭 시 view가 올라가지 않던 버그 수정**
- getNorificationUrls 내 View 호출 API 삭제로 view 카운트 기능 상실
- 별도 onClickHandle 추가로 수정 완료


## PR 유형
어떤 변경 사항이 있나요?
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
